### PR TITLE
Implement task polling in CLI to refresh Kanban board live

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -13,19 +13,21 @@ func GetTasksAndDisplayKanban(taskStore *storage.FileTaskStorage) {
 		return
 	}
 	DisplayKanban(utils.PointerSliceToValueSlice(tasks))
-
-	utils.RequestAction(PalleteCommands(taskStore))
 } 
 
 func Execute() {
 	fmt.Println("Starting AI Orchestrator CLI...")
-	// Call orchestrator and mcp as needed
-	//var tasks = types.ExampleTasks()
 	taskStore, err := storage.NewFileTaskStorage()
 	if err != nil {
 		fmt.Printf("Error initializing task storage: %v\n", err)
 		return
 	}
-	GetTasksAndDisplayKanban(taskStore)
 
+	for {
+		GetTasksAndDisplayKanban(taskStore)
+		result := utils.RequestAction(PalleteCommands(taskStore))
+		if result == "exit" {
+			break
+		}
+	}
 }

--- a/internal/cli/commandPallete.go
+++ b/internal/cli/commandPallete.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"ludwig/internal/orchestrator"
 	"strconv"
+	"os"
 )
 
 func PalleteCommands(taskStore *storage.FileTaskStorage) []utils.Command {
@@ -29,8 +30,6 @@ func PalleteCommands(taskStore *storage.FileTaskStorage) []utils.Command {
 					fmt.Printf("Error adding new task: %v\n", err)
 					return
 				}
-				// Refresh the kanban display
-				GetTasksAndDisplayKanban(taskStore)
 			},
 			Description: "add <task description> - Add a new task. Tasks can be multiple words. No quotation marks needed.",
 		},
@@ -41,7 +40,6 @@ func PalleteCommands(taskStore *storage.FileTaskStorage) []utils.Command {
 				if !checkArgumentsCount(1, parts) { return }
 				utils.Println("Starting AI Orchestrator...")
 				orchestrator.Start()
-				utils.RequestAction(PalleteCommands(taskStore))
 			},
 			Description: "start - Start the AI Orchestrator",
 		},
@@ -55,7 +53,6 @@ func PalleteCommands(taskStore *storage.FileTaskStorage) []utils.Command {
 				}
 				utils.Println("Stopping AI Orchestrator...")
 				orchestrator.Stop()
-				utils.RequestAction(PalleteCommands(taskStore))
 			},
 			Description: "stop - Stop the AI Orchestrator",
 		},
@@ -65,8 +62,6 @@ func PalleteCommands(taskStore *storage.FileTaskStorage) []utils.Command {
 			Action: func(text string) {
 				parts := strings.Fields(text)
 				if !checkArgumentsCount(1, parts) { return }
-
-				GetTasksAndDisplayKanban(taskStore)
 			},
 		},
 		{
@@ -77,7 +72,7 @@ func PalleteCommands(taskStore *storage.FileTaskStorage) []utils.Command {
 				if !checkArgumentsCount(1, parts) { return }
 
 				utils.Println("Exiting CLI...")
-				return
+				os.Exit(0)
 			},
 		},
 	}


### PR DESCRIPTION
Automatically refreshes the display, except when the user is typing in an action. Ollie, in future work you can see if it is possible to make this work, but with the current CLI display setup I don't think it is. Updates also seem to make it only show the current command, rather than previous command, which I think is a bit nicer anyway. 

Overall, might need to look into whether or not there are any better CLI frameworks, cause if Claude code and gemini CLIs can look so cool, with text constantly being generated and added while the user is still able to type and do stuff in their own area, then it must be possible.